### PR TITLE
fix: resolve report truncation under high concurrency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.dvsa.testing.framework</groupId>
     <artifactId>accessibility-ai-core</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
 
     <name>AI-Augmented Accessibility Framework</name>
     <description>A hybrid page crawler that combines axe-core scans with AI-driven semantic analysis.</description>

--- a/src/main/java/org/dvsa/testing/framework/ai/BedrockAgentAnalyser.java
+++ b/src/main/java/org/dvsa/testing/framework/ai/BedrockAgentAnalyser.java
@@ -43,6 +43,91 @@ public class BedrockAgentAnalyser {
         this.agentAliasId = org.dvsa.testing.framework.config.AppConfig.getString("bedrock.agent.alias.id");
     }
 
+    public Map<String, BedrockRecommendation> analyseUniqueViolations(Map<String, Rule> uniqueRules) throws Exception {
+        LOGGER.info("Starting chunked analysis for {} unique rule IDs", uniqueRules.size());
+
+        Map<String, BedrockRecommendation> finalMap = new HashMap<>();
+
+        ConcurrentHashMap<Rule, String> tempMap = new ConcurrentHashMap<>();
+        for (Map.Entry<String, Rule> entry : uniqueRules.entrySet()) {
+            tempMap.put(entry.getValue(), entry.getKey());
+        }
+        String liveContext = buildScrapedContext(tempMap);
+
+        List<Map.Entry<String, Rule>> ruleList = new ArrayList<>(uniqueRules.entrySet());
+        int chunkSize = 3;
+
+        for (int i = 0; i < ruleList.size(); i += chunkSize) {
+            int end = Math.min(i + chunkSize, ruleList.size());
+            List<Map.Entry<String, Rule>> chunk = ruleList.subList(i, end);
+
+            LOGGER.info("Processing chunk {}/{} (Rules {}-{})",
+                    (i / chunkSize) + 1, (int) Math.ceil((double) ruleList.size() / chunkSize), i + 1, end);
+
+            String chunkJson = formatUniqueRulesChunkAsJson(chunk);
+            String finalPrompt = String.format(
+                    """
+                            SYSTEM: You are a GOV.UK Accessibility Auditor. You must fix violations using GOV.UK Design System patterns.
+                            USER: Fix these violations.\s
+                            
+                            MANDATORY OUTPUT RULES:
+                            1. Every item MUST have an 'example' field containing a GDS HTML snippet (e.g. using 'govuk-' classes).
+                            2. If the GDS context doesn't mention the specific rule, use your general knowledge of GOV.UK components (Buttons, Inputs, Headings) to provide the fix.
+                            3. Return ONLY a valid JSON array.
+                            
+                            ### GDS CONTEXT:
+                            %s
+                            
+                            ### VIOLATIONS:
+                            %s
+                            """,
+                    liveContext, chunkJson
+            );
+
+            try {
+                String rawResponse = invokeAgentViaRest(new JSONObject().put("inputText", finalPrompt));
+                List<BedrockRecommendation> recs = parseResponse(rawResponse);
+
+                for (int j = 0; j < recs.size(); j++) {
+                    if (j >= chunk.size()) break;
+
+                    String ruleId = chunk.get(j).getKey();
+                    BedrockRecommendation rec = recs.get(j);
+
+                    finalMap.put(ruleId, BedrockRecommendation.builder()
+                            .ruleId(ruleId)
+                            .issue(rec.issue())
+                            .recommendation(rec.recommendation())
+                            .reference(rec.reference())
+                            .example(rec.example())
+                            .build());
+                }
+
+                if (end < ruleList.size()) {
+                    LOGGER.info("Chunk complete. Sleeping for 1500ms to prevent rate limiting...");
+                    Thread.sleep(1500);
+                }
+
+            } catch (Exception e) {
+                LOGGER.error("Error processing rule chunk starting at index {}: {}", i, e.getMessage());
+            }
+        }
+
+        return finalMap;
+    }
+
+    private String formatUniqueRulesChunkAsJson(List<Map.Entry<String, Rule>> chunk) {
+        JSONArray array = new JSONArray();
+        for (Map.Entry<String, Rule> entry : chunk) {
+            JSONObject obj = new JSONObject();
+            obj.put("ruleId", entry.getKey());
+            obj.put("description", entry.getValue().getDescription());
+            obj.put("impact", entry.getValue().getImpact());
+            array.put(obj);
+        }
+        return array.toString();
+    }
+
     public Map<String, BedrockRecommendation> analyseViolations(ConcurrentHashMap<Rule, String> violations) throws Exception {
         LOGGER.info("Starting chunked analysis for {} violations", violations.size());
 

--- a/src/main/java/org/dvsa/testing/framework/axe/AXEScanner.java
+++ b/src/main/java/org/dvsa/testing/framework/axe/AXEScanner.java
@@ -23,14 +23,18 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import static org.dvsa.testing.framework.axe.HtmlReportGenerator.generateHtmlReport;
 
 public class AXEScanner {
 
     private static final Logger LOGGER = LogManager.getLogger(AXEScanner.class);
-    private static final ConcurrentHashMap<Rule, String> allViolations = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<String, String> pageScreenshots = new ConcurrentHashMap<>(); // URL -> screenshot path
+    private static final CopyOnWriteArrayList<ViolationEntry> allViolations = new CopyOnWriteArrayList<>();
+    private static final ConcurrentHashMap<String, String> pageScreenshots = new ConcurrentHashMap<>();
+
+    public record ViolationEntry(Rule rule, String pageUrl) {}
 
     public AXEScanner() {
     }
@@ -118,7 +122,7 @@ public class AXEScanner {
         return url == null || url.startsWith("about:") || url.isEmpty();
     }
 
-    public static ConcurrentHashMap<Rule, String> getAllViolations() {
+    public static CopyOnWriteArrayList<ViolationEntry> getAllViolations() {
         return allViolations;
     }
 
@@ -133,24 +137,38 @@ public class AXEScanner {
             return;
         }
 
+        List<ViolationEntry> snapshot = new ArrayList<>(allViolations);
+        LOGGER.info("Generating report for {} total violation instances across {} pages...",
+                snapshot.size(),
+                snapshot.stream().map(ViolationEntry::pageUrl).distinct().count());
+
+        Map<String, Rule> uniqueRules = snapshot.stream()
+                .collect(Collectors.toMap(
+                        e -> e.rule().getId(),
+                        ViolationEntry::rule,
+                        (existing, replacement) -> existing
+                ));
+
+        LOGGER.info("Deduplicated to {} unique rule IDs for Bedrock analysis (from {} total violations)",
+                uniqueRules.size(), snapshot.size());
+
         try {
             LOGGER.info("Generating report with Bedrock recommendations & Live Scraped Context...");
 
             BedrockAgentAnalyser analyser = new BedrockAgentAnalyser();
 
-            Map<String, BedrockRecommendation> recommendationMap = analyser.analyseViolations(allViolations);
+            Map<String, BedrockRecommendation> recommendationMap = analyser.analyseUniqueViolations(uniqueRules);
 
             if (recommendationMap == null || recommendationMap.isEmpty()) {
                 LOGGER.warn("No AI recommendations received from Bedrock. Falling back to basic report.");
-                generateBasicReport();
+                generateBasicReport(snapshot);
                 return;
             }
 
-            LOGGER.info("DEBUG: Keys in Bedrock Map: {}", recommendationMap.keySet());
-            LOGGER.info("DEBUG: Keys in Violations Map: {}", allViolations.keySet().stream().map(Rule::getId).toList());
+            LOGGER.info("Bedrock recommendations received for rules: {}", recommendationMap.keySet());
 
             String htmlContent = HtmlReportGenerator.generateHtmlReport(
-                    allViolations,
+                    snapshot,
                     recommendationMap,
                     new HashMap<>(),
                     pageScreenshots
@@ -162,16 +180,16 @@ public class AXEScanner {
 
         } catch (Exception e) {
             LOGGER.error("Failed to generate AI report: {}", e.getMessage(), e);
-            generateBasicReport();
+            generateBasicReport(snapshot);
         }
     }
 
-    static void generateBasicReport() {
+    static void generateBasicReport(List<ViolationEntry> snapshot) {
         try {
             Map<String, BedrockRecommendation> emptyRecommendations = new HashMap<>();
             Map<String, BedrockRecommendation> emptyKbMap = new HashMap<>();
 
-            String htmlContent = generateHtmlReport(getAllViolations(), emptyRecommendations, emptyKbMap, getPageScreenshots());
+            String htmlContent = generateHtmlReport(snapshot, emptyRecommendations, emptyKbMap, getPageScreenshots());
             bufferedFileWriter(htmlContent);
 
             LOGGER.info("Basic accessibility report generated successfully (without AI recommendations).");
@@ -190,7 +208,7 @@ public class AXEScanner {
             LOGGER.info("Created directory: {}", "target/reports");
         }
 
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(folderName + dateTime + fileName, true))) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(folderName + dateTime + fileName, false))) {
             writer.write(content);
         } catch (Exception e) {
             LOGGER.error(e);
@@ -203,7 +221,7 @@ public class AXEScanner {
             pageScreenshots.computeIfAbsent(url, k -> captureScreenshot(driver, url));
 
             for (Rule rule : violations) {
-                allViolations.put(rule, url);
+                allViolations.add(new ViolationEntry(rule, url));
             }
 
             LOGGER.info("Found {} violations on {}", violations.size(), url);

--- a/src/main/java/org/dvsa/testing/framework/axe/HtmlReportGenerator.java
+++ b/src/main/java/org/dvsa/testing/framework/axe/HtmlReportGenerator.java
@@ -6,9 +6,8 @@ import org.dvsa.testing.framework.ai.BedrockRecommendation;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -30,13 +29,12 @@ public class HtmlReportGenerator {
     }
 
     public static String generateHtmlReport(
-            ConcurrentHashMap<Rule, String> rules,
+            List<AXEScanner.ViolationEntry> violations,
             Map<String, BedrockRecommendation> bedrockRecommendationMap,
             Map<String, BedrockRecommendation> kbMap,
             Map<String, String> pageScreenshots
     ) {
         StringBuilder htmlReport = new StringBuilder();
-        Set<String> seenRulesIds = new HashSet<>();
 
         htmlReport.append("<!DOCTYPE html>\n")
                 .append("<html><head><meta charset='UTF-8'><title>Accessibility Report</title>")
@@ -55,6 +53,7 @@ public class HtmlReportGenerator {
                 .append(".download-btn:hover { background-color: #005a27; }")
                 .append(".modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.9); overflow: auto; }")
                 .append(".modal-content { margin: auto; display: block; width: 80%; max-width: 1200px; padding: 40px 0; }")
+                .append(".summary { background: #f3f2f1; padding: 15px; margin-bottom: 20px; border-left: 4px solid #1d70b8; }")
                 .append("</style>")
                 .append("<script>")
                 .append("function openModal(src) { document.getElementById('screenshotModal').style.display='block'; document.getElementById('modalImage').src=src; }")
@@ -62,6 +61,11 @@ public class HtmlReportGenerator {
                 .append("</script>")
                 .append("</head><body>")
                 .append("<h1>Accessibility Report (AI Augmented)</h1>")
+                .append("<div class='summary'>")
+                .append("<strong>Total violation instances:</strong> ").append(violations.size())
+                .append(" | <strong>Unique rules:</strong> ").append(violations.stream().map(e -> e.rule().getId()).distinct().count())
+                .append(" | <strong>Pages scanned:</strong> ").append(violations.stream().map(AXEScanner.ViolationEntry::pageUrl).distinct().count())
+                .append("</div>")
                 .append("<table><tr>")
                 .append("<th style='width: 12%;'>Source URL</th>")
                 .append("<th style='width: 18%;'>Screenshot</th>")
@@ -78,11 +82,9 @@ public class HtmlReportGenerator {
                 "moderate", "#4c2c92"
         );
 
-        for (Map.Entry<Rule, String> ruleEntry : rules.entrySet()) {
-            Rule rule = ruleEntry.getKey();
-            String pageUrl = ruleEntry.getValue();
-
-            if (!seenRulesIds.add(rule.getId())) continue;
+        for (AXEScanner.ViolationEntry entry : violations) {
+            Rule rule = entry.rule();
+            String pageUrl = entry.pageUrl();
 
             String impactColor = impactColors.getOrDefault(rule.getImpact(), "#505a5f");
 

--- a/src/main/java/org/dvsa/testing/framework/jsoup/SpiderCrawler.java
+++ b/src/main/java/org/dvsa/testing/framework/jsoup/SpiderCrawler.java
@@ -15,7 +15,6 @@ import org.openqa.selenium.WebDriver;
 
 import java.net.URI;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 
@@ -24,8 +23,6 @@ public class SpiderCrawler {
     private static final Logger LOGGER = LogManager.getLogger(SpiderCrawler.class);
     private static final int MAX_CRAWL_DEPTH = 30;
     private static final int MAX_URLS_PER_DOMAIN = 1000;
-
-    private static final Set<String> visitedUrls = ConcurrentHashMap.newKeySet();
 
     private static final List<String> BLACKLISTED_PATHS = Arrays.asList(
             System.getProperty("scanner.exclude.paths", "/topsreport").split(",")


### PR DESCRIPTION
Root causes fixed:
- HtmlReportGenerator used seenRulesIds HashSet that skipped all but the first violation per rule ID — 50 color-contrast violations across 50 pages would only show 1 row in the report
- BedrockAgentAnalyser was called for EVERY violation instance (hundreds of Bedrock API calls with 1.5s delays each) causing rate limiting and timeouts that silently dropped recommendations
- AXEScanner stored violations in ConcurrentHashMap<Rule, String> which could overwrite entries when Rule hashCode collides
- bufferedFileWriter used append mode creating malformed HTML when called from multiple threads
- SpiderCrawler had unused static visitedUrls field

Changes:
- Bump version to 2.0.0 (breaking: API signature changes)
- Replace ConcurrentHashMap<Rule,String> with CopyOnWriteArrayList of ViolationEntry records preserving ALL violation+URL pairs
- Deduplicate by rule ID BEFORE calling Bedrock (analyseUniqueViolations) reducing API calls from hundreds to ~5-10 unique rules
- Remove seenRulesIds filter so report shows every violation instance with its specific page URL and failing HTML
- Add summary banner showing total violations, unique rules, pages
- Fix FileWriter to overwrite (false) not append (true)
- Remove dead static visitedUrls from SpiderCrawler

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
