### PR TITLE
fix: resolve high-severity Snyk vulnerabilities in transitive depende…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,9 @@
         <selenium.version>4.40.0</selenium.version>
         <aws.sdk.version>2.41.26</aws.sdk.version>
         <jackson.version>3.1.1</jackson.version>
+        <jackson2.version>2.21.2</jackson2.version>
         <jackson.datatype.versionn>3.0.0-rc2</jackson.datatype.versionn>
+        <netty.version>4.1.133.Final</netty.version>
         <slf4j.version>2.0.7</slf4j.version>
         <json.version>20250517</json.version>
         <faker.version>2.5.4</faker.version>
@@ -48,6 +50,59 @@
                 <version>${aws.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Override transitive Jackson 2.x from axe-core to fix SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924 and SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551 -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <!-- Override transitive Netty from AWS SDK to fix SNYK-JAVA-IONETTY-16438322, SNYK-JAVA-IONETTY-16438930, SNYK-JAVA-IONETTY-16438929 -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>${netty.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
…ncies

Override transitive dependency versions to fix:
- SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924: jackson-core 2.20.1 → 2.21.2
- SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551: jackson-core 2.20.1 → 2.21.2
- SNYK-JAVA-IONETTY-16438322: netty-codec 4.1.130 → 4.1.133.Final
- SNYK-JAVA-IONETTY-16438930: netty-codec 4.1.130 → 4.1.133.Final
- SNYK-JAVA-IONETTY-16438929: netty-codec-http2 4.1.132 → 4.1.133.Final

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
