### PR TITLE
fix(deps): bump tools.jackson.core:jackson-databind to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <playwright.version>1.59.0</playwright.version>
         <selenium.version>4.43.0</selenium.version>
         <aws.sdk.version>2.44.0</aws.sdk.version>
-        <jackson.version>3.1.1</jackson.version>
+        <jackson.version>3.2.1</jackson.version>
         <jackson2.version>2.21.2</jackson2.version>
         <jackson.datatype.versionn>3.0.0-rc2</jackson.datatype.versionn>
         <netty.version>4.1.133.Final</netty.version>


### PR DESCRIPTION
Addresses SNYK-JAVA-TOOLSJACKSONCORE-17972609 (Incorrect Authorization, High severity) in tools.jackson.core:jackson-databind 3.1.x.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
